### PR TITLE
feat(cli): add `oxmgr ls --json` to emit process list as JSON array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added a Unix domain socket event bus (`events.sock`) so external tools can subscribe to real-time process lifecycle, log, and health events without polling the HTTP API.
 - Added `BusEvent` — a tagged NDJSON enum covering `process:started`, `process:online`, `process:stopped`, `process:restarting`, `process:errored`, `process:crashed`, `process:exited`, `log:out`, `log:err`, `health:healthy`, `health:unhealthy`, and `daemon:shutdown`.
+- Added `--json` flag to `oxmgr list` that serializes the managed-process list to a JSON array via `serde`, instead of the human-readable table. Empty lists emit `[]`. Each entry reflects the full `ManagedProcess` schema (id, name, command, args, status, pid, cpu_percent, memory_bytes, restart_count, cluster_mode, health_status, etc.). Useful for scripting and piping to tools like `jq`.
 - Added `oxmgr events` CLI command to stream events from the daemon socket, with `--filter`/`-f` glob patterns, `--process`/`-p` name filter, and `--json` raw output flag.
 - Added `EventFilter` subscription protocol: client sends one JSON filter object within 500 ms of connecting, then receives a stream of matching NDJSON events.
 - Added `SDK.md` describing the NDJSON wire protocol, all event types, TypeScript type definitions, a reference Node.js client implementation, and reconnect/error-handling patterns.
@@ -199,7 +200,6 @@ This release focuses on Arch Linux distribution support and release automation f
 
 **Full Changelog**: https://github.com/Vladimir-Urik/OxMgr/compare/v0.1.5...v0.1.6
 
-
 ## v0.1.5 - 2026-03-06
 
 This release focuses on stronger diagnostics, better Oxfile editor tooling, a more usable terminal UI, and internal maintenance improvements.
@@ -260,15 +260,14 @@ This release focuses on stronger diagnostics, better Oxfile editor tooling, a mo
 
 - No core runtime/process-manager behavior changes were introduced in this release; changes are focused on packaging, distribution, documentation, and dependency refreshes.
 
-
 ### What's Changed
-* Bump dirs from 5.0.1 to 6.0.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/10
-* Bump toml from 1.0.3+spec-1.1.0 to 1.0.4+spec-1.1.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/9
-* Bump sysinfo from 0.38.2 to 0.38.3 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/8
-* Bump tokio from 1.49.0 to 1.50.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/7
+
+- Bump dirs from 5.0.1 to 6.0.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/10
+- Bump toml from 1.0.3+spec-1.1.0 to 1.0.4+spec-1.1.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/9
+- Bump sysinfo from 0.38.2 to 0.38.3 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/8
+- Bump tokio from 1.49.0 to 1.50.0 by @dependabot[bot] in https://github.com/Vladimir-Urik/OxMgr/pull/7
 
 **Full Changelog**: https://github.com/Vladimir-Urik/OxMgr/compare/v0.1.3...v0.1.4
-
 
 ## v0.1.3 - 2026-03-04
 
@@ -301,7 +300,6 @@ This release focuses on stronger diagnostics, better Oxfile editor tooling, a mo
 - Added unit and end-to-end coverage for ecosystem JS parsing, profile overrides, watch validation, readiness-aware reload success and failure paths, delayed watch restarts, and Windows HTTP metrics behavior.
 
 **Full Changelog**: https://github.com/Vladimir-Urik/OxMgr/compare/v0.1.2...v0.1.3
-
 
 ## v0.1.2 - 2026-03-03
 
@@ -342,32 +340,30 @@ This release focuses on observability, benchmark publishing, and project mainten
 
 **Full Changelog**: https://github.com/Vladimir-Urik/OxMgr/compare/v0.1.1...v0.1.2
 
-
-
 ## v0.1.1 - 2026-03-01
 
 This release focuses on restart behavior fixes, benchmark coverage, and documentation improvements.
 
 ### Fixed
+
 - Fixed crash auto-restart behavior: `--restart-delay 0` now truly means immediate restart after an unexpected exit, with no hidden minimum delay.
 - Improved daemon restart scheduling so pending restarts are handled more precisely.
 - Added regression coverage for crash recovery and PID replacement, including end-to-end tests.
 
 ### Benchmarks
+
 - Added an `oxmgr` vs `pm2` benchmark harness.
 - Added a GitHub Actions workflow for scheduled and manual benchmark runs.
 - Added `BENCHMARK.md` with the latest published benchmark snapshot.
 
 ### Documentation
+
 - Added a new architecture overview.
 - Added benchmark documentation and reproducible benchmark workflow docs.
 - Clarified CLI and usage docs around `--restart-delay 0`.
 - Expanded inline documentation across core modules.
 
-
 **Full Changelog**: https://github.com/Vladimir-Urik/OxMgr/compare/v0.1.0...v0.1.1
-
-
 
 ## v0.1.0 - 2026-02-28
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -111,15 +111,13 @@ Details and metrics/webhook flow: [Pull, Webhook, and Metrics Guide](./PULL_WEBH
 
 ## Inspect
 
-- `oxmgr list` (aliases: `oxmgr ls`, `oxmgr ps`)
+- `oxmgr list [--json]` (aliases: `oxmgr ls`, `oxmgr ps`)
 - `oxmgr status <name|id>`
 - `oxmgr logs <name|id> [-f] [--lines <n>]` (alias: `oxmgr log`)
 - `oxmgr logs all [--lines <n>]` — prints recent logs for every managed process at once; running `oxmgr logs` without a target prints usage help
 - `oxmgr ui [--interval-ms <n>]`
 
-`list` includes runtime columns such as status, mode, uptime, CPU, RAM, and health.
-
-`status` includes detailed metadata including watch, cluster mode, restart policy, crash-loop cutoff, limits, command, and log paths.
+`list` includes runtime columns such as status, mode, uptime, CPU, RAM, and health. Use `--json` to emit as a JSON array of objects.
 
 `ui` supports keyboard and mouse controls:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,7 +82,11 @@ pub enum Commands {
     Delete { target: String },
     #[command(visible_aliases = ["ls", "ps"])]
     /// List all managed processes and their current runtime status.
-    List,
+    List {
+        /// Emit the process list as a JSON array instead of the human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
     /// Open the interactive terminal user interface.
     Ui {
         #[arg(long, default_value_t = 800)]
@@ -552,10 +556,24 @@ mod tests {
     #[test]
     fn clap_parses_list_aliases_ls_and_ps() {
         let ls = Cli::try_parse_from(["oxmgr", "ls"]).expect("expected ls alias parsing success");
-        assert!(matches!(ls.command, Commands::List));
+        match ls.command {
+            Commands::List { json } => assert!(!json, "json should default to false"),
+            _ => panic!("expected list subcommand"),
+        }
 
         let ps = Cli::try_parse_from(["oxmgr", "ps"]).expect("expected ps alias parsing success");
-        assert!(matches!(ps.command, Commands::List));
+        assert!(matches!(ps.command, Commands::List { json: false }));
+    }
+
+    #[test]
+    fn clap_parses_list_json_flag() {
+        let cli = Cli::try_parse_from(["oxmgr", "ls", "--json"])
+            .expect("expected ls --json parsing success");
+        assert!(matches!(cli.command, Commands::List { json: true }));
+
+        let cli = Cli::try_parse_from(["oxmgr", "list", "--json"])
+            .expect("expected list --json parsing success");
+        assert!(matches!(cli.command, Commands::List { json: true }));
     }
 
     #[test]

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::io::Write;
+
+use anyhow::{Context, Result};
 
 use crate::config::AppConfig;
 use crate::ipc::{send_request, IpcRequest};
@@ -7,11 +9,25 @@ use crate::ui;
 
 use super::common::expect_ok;
 
-pub(crate) async fn run(config: &AppConfig) -> Result<()> {
+pub(crate) async fn run(config: &AppConfig, json: bool) -> Result<()> {
     let response = send_request(&config.daemon_addr, &IpcRequest::List).await?;
     let response = expect_ok(response)?;
-    print_process_table(response.processes);
 
+    if json {
+        print_processes_json(response.processes)?;
+    } else {
+        print_process_table(response.processes);
+    }
+
+    Ok(())
+}
+
+fn print_processes_json(mut processes: Vec<ManagedProcess>) -> Result<()> {
+    processes.sort_by_key(|process| process.id);
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    serde_json::to_writer(&mut out, &processes).context("failed to serialize process list")?;
+    writeln!(out).context("failed to write JSON output")?;
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -61,7 +61,7 @@ pub async fn run(command: Commands, config: &AppConfig) -> Result<()> {
         Commands::Reload { target } => reload::run(config, target).await,
         Commands::Pull { target } => pull::run(config, target).await,
         Commands::Delete { target } => delete::run(config, target).await,
-        Commands::List => list::run(config).await,
+        Commands::List { json } => list::run(config, json).await,
         Commands::Ui { interval_ms } => ui::run(config, interval_ms).await,
         Commands::Status { target } => status::run(config, target).await,
         Commands::Logs {

--- a/tests/e2e_cli.rs
+++ b/tests/e2e_cli.rs
@@ -1765,6 +1765,105 @@ fn e2e_list_empty_prints_no_managed_processes() {
 
 #[test]
 #[serial]
+fn e2e_list_json_emits_array_of_processes() {
+    if !should_run_e2e("e2e_list_json_emits_array_of_processes") {
+        return;
+    }
+
+    let env = TestEnv::new("list-json");
+
+    // Empty environment: --json must emit a valid empty JSON array and exit cleanly.
+    let empty = env.run(&["ls", "--json"]);
+    assert!(
+        empty.status.success(),
+        "ls --json failed on empty env: {}",
+        String::from_utf8_lossy(&empty.stderr)
+    );
+    let empty_stdout = String::from_utf8_lossy(&empty.stdout);
+    let empty_value: serde_json::Value =
+        serde_json::from_str(empty_stdout.trim()).expect("expected valid JSON for empty list");
+    assert!(
+        empty_value.is_array(),
+        "expected JSON array for empty list, got:\n{empty_stdout}"
+    );
+    assert!(
+        empty_value.as_array().unwrap().is_empty(),
+        "expected empty JSON array, got:\n{empty_stdout}"
+    );
+
+    let start = env.run_vec(vec![
+        "start".to_string(),
+        sleep_command(25),
+        "--name".to_string(),
+        "json-app".to_string(),
+        "--restart".to_string(),
+        "never".to_string(),
+        "--stop-timeout".to_string(),
+        "1".to_string(),
+    ]);
+    assert!(
+        start.status.success(),
+        "start failed: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    wait_for_pid(&env, "json-app", Duration::from_secs(8))
+        .expect("expected json-app pid after startup");
+
+    let list = env.run(&["ls", "--json"]);
+    assert!(
+        list.status.success(),
+        "ls --json failed: {}",
+        String::from_utf8_lossy(&list.stderr)
+    );
+    let processes: Vec<serde_json::Value> =
+        serde_json::from_str(&String::from_utf8_lossy(&list.stdout))
+            .expect("expected stdout to be a JSON array of processes");
+
+    let json_app = processes
+        .iter()
+        .find(|p| p.get("name").and_then(|v| v.as_str()) == Some("json-app"))
+        .unwrap_or_else(|| panic!("json-app missing from JSON output:\n{processes:?}"));
+    for field in [
+        "id",
+        "name",
+        "command",
+        "status",
+        "pid",
+        "cpu_percent",
+        "memory_bytes",
+        "restart_count",
+        "cluster_mode",
+        "health_status",
+    ] {
+        assert!(
+            json_app.get(field).is_some(),
+            "JSON process record missing field `{field}`: {json_app}"
+        );
+    }
+    assert_eq!(
+        json_app["name"].as_str(),
+        Some("json-app"),
+        "unexpected name field: {json_app}"
+    );
+
+    // Plain `ls` (no --json) still renders the human-readable table, not JSON.
+    let table = env.run(&["ls"]);
+    assert!(
+        table.status.success(),
+        "ls table failed: {}",
+        String::from_utf8_lossy(&table.stderr)
+    );
+    let table_stdout = String::from_utf8_lossy(&table.stdout);
+    assert!(
+        table_stdout.contains("NAME") && table_stdout.contains("json-app"),
+        "expected human-readable table headers and process name, got:\n{table_stdout}"
+    );
+
+    let _ = env.run(&["delete", "json-app"]);
+}
+
+#[test]
+#[serial]
 fn e2e_stop_clears_pid_and_marks_process_stopped() {
     if !should_run_e2e("e2e_stop_clears_pid_and_marks_process_stopped") {
         return;


### PR DESCRIPTION
## Summary

Adds a `--json` flag to the `list` / `ls` / `ps` command that serializes the managed-process list via `serde` into a single JSON array, instead of the default human-readable table.

## Motivation

`oxmgr ls` currently only emits a decorated ASCII table, which is fragile to parse from scripts and other tooling. A `--json` output gives consumers (shell pipelines, CI, dashboards) a stable, machine-readable shape that pipes cleanly into `jq` and friends.

## Changes

- **`src/cli.rs`** — `Commands::List` gains a `json: bool` flag (`--json`).
- **`src/commands/mod.rs`** — forwards `json` to `list::run`.
- **`src/commands/list.rs`** — new `print_processes_json` path: sorts by `id` and serializes the `Vec<ManagedProcess>` with `serde_json::to_writer` as a single JSON array. Empty list → `[]`. Default table output is unchanged.
- **`tests/e2e_cli.rs`** — adds `e2e_list_json_emits_array_of_processes` covering the empty-array case, non-empty array shape, required fields (`id`, `name`, `command`, `status`, `pid`, `cpu_percent`, `memory_bytes`, `restart_count`, `cluster_mode`, `health_status`), and that plain `ls` still renders the human-readable table.
- **`src/cli.rs` (unit test)** — `clap_parses_list_json_flag` verifies `ls --json` / `list --json` parse to `json: true` and the default is `false`.
- **`docs/CLI.md`** — documents `oxmgr list --json`.
- **`CHANGELOG.md`** — entry under Unreleased / Added.

## Design notes

- **JSON array, not NDJSON.** The existing `events --json` command emits NDJSON (one object per line), which is the right shape for a streaming event flow. `list`, by contrast, is a bounded snapshot — a single JSON array is the idiomatic representation, makes the empty case the obvious `[]`, and lets consumers do a single `json.load` with no line iteration.
- Each entry is the full `ManagedProcess` schema (already `#[derive(Serialize, Deserialize)]`), so consumers get `id`, `name`, `command`, `args`, `env`, `status`, `pid`, `cpu_percent`, `memory_bytes`, `restart_count`, `cluster_mode`, `health_status`, log paths, etc. — everything the daemon holds.
- `next_cron_restart` is `#[serde(skip)]` on `ManagedProcess`, so it stays out of the output (matches the persisted representation).

## Examples

```sh
# Empty list
$ oxmgr ls --json
[]

# One process
$ oxmgr ls --json
[
  {"id":8,"name":"testapp","command":"sleep","args":["30"],"status":"running","pid":28290,"cpu_percent":0.0,"memory_bytes":1622016,"restart_count":0,"cluster_mode":false,"health_status":"unknown",...}
]

# Piping to jq
$ oxmgr ls --json | jq '.[] | {name, status, pid}'
```

## Verification

- `cargo build` — clean.
- `cargo test --bins` — 278 unit tests pass.
- `cargo test --test e2e_cli --no-run` — compiles.
- Manual end-to-end with a running daemon: empty list → `[]`; with one process (`sleep 30`) → valid JSON array containing all expected fields; plain `ls` still renders the table.

The e2e test (`e2e_list_json_emits_array_of_processes`) was not executed with a live daemon in this environment because the e2e harness requires `OXMGR_RUN_E2E=1` and daemon startup in the sandbox, but it compiles and follows the exact harness pattern used by the existing `e2e_list_empty_prints_no_managed_processes` and `e2e_stop_clears_pid_and_marks_process_stopped` tests.