### PR TITLE
Safeguarding against dangling child processes on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased (branch windows-job-objects)
+
+### Added
+
+- On Windows, every managed process is now assigned to a dedicated Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, guaranteeing that no descendant can outlive its managed root or the daemon. This closes orphan-process gaps that `taskkill /T` alone cannot cover: children of a crashed application, descendants re-parented after an intermediate process exits, processes spawned mid-kill, and trees left behind when the daemon itself is force-killed. After a root exits, surviving descendants get up to `stop_timeout_secs` to finish before the job is terminated; the exit event (and any restart) is deferred until the sweep completes so a new instance never races leftovers for ports or files. If job creation or assignment fails (e.g. nested-job restrictions), oxmgr logs a warning and falls back to the previous `taskkill`-based cleanup.
+
 ## v0.5.0 - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,24 +22,33 @@ regex = "1.11"
 sysinfo = "0.39"
 thiserror = "2.0"
 tokio = { version = "1.52", features = [
-    "macros",
-    "rt-multi-thread",
-    "net",
-    "process",
-    "signal",
-    "fs",
-    "time",
-    "io-util",
-    "sync",
+  "macros",
+  "rt-multi-thread",
+  "net",
+  "process",
+  "signal",
+  "fs",
+  "time",
+  "io-util",
+  "sync",
 ] }
 toml = "1.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1.0", default-features = false, features = [
+  "rust_backend",
+] }
 url = "2.5"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.31", features = ["signal", "process", "user"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_JobObjects",
+] }
 
 [dev-dependencies]
 serial_test = "3.5"

--- a/src/process_manager.rs
+++ b/src/process_manager.rs
@@ -58,6 +58,8 @@ use crate::storage::{load_state, save_state, PersistedState};
 
 mod git;
 mod health;
+#[cfg(windows)]
+mod job;
 mod restart;
 mod runtime;
 mod spawn;
@@ -1388,6 +1390,26 @@ impl ProcessManager {
             .with_context(|| format!("failed to spawn {}", process.command))?;
         let pid = child.id().context("spawned child has no pid")?;
 
+        // Bind the child's process tree to a kill-on-close job object so no
+        // descendant can outlive the managed process (or the daemon itself).
+        // Failure degrades to taskkill-only cleanup rather than aborting the
+        // spawn, e.g. on hosts where the daemon runs inside a job that
+        // disallows nesting.
+        #[cfg(windows)]
+        let job = match job::JobObject::create().and_then(|job| {
+            job.assign(&child)?;
+            Ok(job)
+        }) {
+            Ok(job) => Some(job),
+            Err(err) => {
+                warn!(
+                    "failed to attach process {} to a job object; orphaned child cleanup will rely on taskkill only: {}",
+                    process.name, err
+                );
+                None
+            }
+        };
+
         let process_info = EventProcessInfo::from(process as &ManagedProcess);
         // Refresh pid in the info we pass to log pipes (process.pid set after spawn).
         let process_info = EventProcessInfo {
@@ -1446,6 +1468,8 @@ impl ProcessManager {
 
         let tx = self.exit_tx.clone();
         let name = process.name.clone();
+        #[cfg(windows)]
+        let survivor_grace = Duration::from_secs(process.stop_timeout_secs.max(1));
         tokio::spawn(async move {
             let event = match child.wait().await {
                 Ok(status) => ProcessExitEvent {
@@ -1468,6 +1492,14 @@ impl ProcessManager {
                     }
                 }
             };
+
+            // Sweep children that outlived the root (crash or partial
+            // taskkill) before reporting the exit, so a restart never races
+            // against leftovers still holding ports or files.
+            #[cfg(windows)]
+            if let Some(job) = job {
+                job.reap_survivors(&event.name, survivor_grace).await;
+            }
 
             let _ = tx.send(event);
         });

--- a/src/process_manager/job.rs
+++ b/src/process_manager/job.rs
@@ -1,0 +1,184 @@
+//! Windows Job Object wrapper used to bind the lifetime of a managed process
+//! tree to the daemon.
+//!
+//! Every spawned child is assigned to a dedicated job configured with
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Descendants inherit job membership
+//! automatically, so the OS kills the entire tree when the last job handle is
+//! closed — even if the daemon itself is force-killed. This closes the gaps
+//! that `taskkill /T` cannot cover (children re-parented after an intermediate
+//! process exits, processes spawned mid-kill, crashed roots whose children
+//! outlive them).
+
+use std::io;
+use std::mem::size_of;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+use std::ptr::{null, null_mut};
+use std::time::Duration;
+
+use tokio::time::sleep;
+use tracing::warn;
+
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectBasicAccountingInformation,
+    JobObjectExtendedLimitInformation, QueryInformationJobObject, SetInformationJobObject,
+    TerminateJobObject, JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+
+/// Owns a job handle; dropping it closes the handle, which terminates any
+/// processes still in the job thanks to kill-on-close.
+pub(super) struct JobObject {
+    handle: OwnedHandle,
+}
+
+impl JobObject {
+    /// Creates an anonymous job with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` set.
+    pub(super) fn create() -> io::Result<Self> {
+        let raw = unsafe { CreateJobObjectW(null(), null()) };
+        if raw.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let handle = unsafe { OwnedHandle::from_raw_handle(raw) };
+
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let ok = unsafe {
+            SetInformationJobObject(
+                handle.as_raw_handle() as HANDLE,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const core::ffi::c_void,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(Self { handle })
+    }
+
+    /// Assigns a freshly spawned child to the job. Descendants spawned by the
+    /// child afterwards join the job automatically.
+    ///
+    /// Processes the child spawned in the window between `CreateProcess` and
+    /// this call are not captured; the window is microseconds wide and closing
+    /// it would require spawning suspended, which `tokio::process` does not
+    /// expose.
+    pub(super) fn assign(&self, child: &tokio::process::Child) -> io::Result<()> {
+        let Some(process_handle) = child.raw_handle() else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "child has no process handle (already reaped)",
+            ));
+        };
+        let ok = unsafe {
+            AssignProcessToJobObject(self.handle.as_raw_handle() as HANDLE, process_handle)
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Number of processes currently alive inside the job.
+    fn active_process_count(&self) -> io::Result<u32> {
+        let mut info: JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { std::mem::zeroed() };
+        let ok = unsafe {
+            QueryInformationJobObject(
+                self.handle.as_raw_handle() as HANDLE,
+                JobObjectBasicAccountingInformation,
+                &mut info as *mut _ as *mut core::ffi::c_void,
+                size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(info.ActiveProcesses)
+    }
+
+    fn terminate(&self) -> io::Result<()> {
+        let ok = unsafe { TerminateJobObject(self.handle.as_raw_handle() as HANDLE, 1) };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    /// Called after the root process has exited: gives surviving descendants
+    /// up to `grace` to finish on their own (they may still be handling the
+    /// graceful `taskkill` close request), then terminates whatever is left.
+    /// Consumes the job; dropping the handle keeps kill-on-close as a final
+    /// backstop.
+    pub(super) async fn reap_survivors(self, name: &str, grace: Duration) {
+        let deadline = tokio::time::Instant::now() + grace;
+        loop {
+            match self.active_process_count() {
+                Ok(0) => return,
+                Ok(_) => {}
+                Err(err) => {
+                    warn!("failed to query job object for process {name}: {err}");
+                    break;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            sleep(Duration::from_millis(200)).await;
+        }
+
+        match self.terminate() {
+            Ok(()) => warn!("terminated orphaned child processes left behind by process {name}"),
+            Err(err) => warn!("failed to terminate job object for process {name}: {err}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+
+    /// `ping -n <count>` is the portable way to keep a console child alive
+    /// without needing stdin (unlike `timeout`, which rejects redirected input).
+    fn spawn_ping() -> tokio::process::Child {
+        tokio::process::Command::new("ping")
+            .args(["-n", "30", "127.0.0.1"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn ping")
+    }
+
+    #[tokio::test]
+    async fn terminate_kills_assigned_child() {
+        let job = JobObject::create().expect("create job");
+        let mut child = spawn_ping();
+        job.assign(&child).expect("assign child to job");
+        assert_eq!(job.active_process_count().unwrap(), 1);
+
+        job.terminate().expect("terminate job");
+        let status = tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("child did not exit after job termination")
+            .expect("wait failed");
+        assert!(!status.success());
+        assert_eq!(job.active_process_count().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn reap_survivors_returns_quickly_when_job_is_empty() {
+        let job = JobObject::create().expect("create job");
+        let mut child = spawn_ping();
+        job.assign(&child).expect("assign child to job");
+        child.kill().await.expect("kill child");
+        let _ = child.wait().await;
+
+        let start = std::time::Instant::now();
+        job.reap_survivors("test", Duration::from_secs(10)).await;
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+}


### PR DESCRIPTION
Using JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE to ensure child processes are not left dangling when the root process crashes or stops. This is the main issue that I have encountered with PM2 in production.

OxMgr already does a better job at this than PM2 when stopping the process, but I've found that a process that spawns a child, then crashes, leaves its orphaned child process behind, dangling.
With these changes, that does not happen. After `--stop-timeout`, any descendants are cleaned up and you are never left with orphaned processes.